### PR TITLE
Add RX/TX matching network configuration options

### DIFF
--- a/src/limedriver.h
+++ b/src/limedriver.h
@@ -24,12 +24,14 @@
 #include <direct.h> // _mkdir
 #endif
 
-#define VERSION "0.2.0"
+#define VERSION "0.3.0"
 
 struct LimeConfig_t {
 
   float srate;
   int channel;
+  int RX_matching;
+  int TX_matching;
   float frq;
   float frq_set;
   float RX_LPF;


### PR DESCRIPTION
Introduced configuration options for RX and TX matching networks in the LimeDriver, enabling manual specification of the reception and transmission paths. This change also includes default logic to maintain previous behavior when new options are unset. Additionally, bumped the version to 0.3.0 to reflect new feature addition. This enhancement provides flexibility for advanced users to optimize signal chain characteristics based on specific requirements.