### PR TITLE
Channel selection fixes

### DIFF
--- a/src/limedriver.cpp
+++ b/src/limedriver.cpp
@@ -133,7 +133,7 @@ lms_device_t *openDevice(const std::string &info) {
   cout << "Opening device: " << info_string << endl;
 
   lms_device_t *dev = NULL;
-  if (LMS_Open(&dev, info.c_str(), NULL)) {
+  if (LMS_Open(&dev, info_string.c_str(), NULL)) {
     error();
   }
 

--- a/src/limedriver.cpp
+++ b/src/limedriver.cpp
@@ -15,6 +15,7 @@ h5c++ -shlib limedriver.cpp -std=c++11 -lLimeSuite -o limedriver
 
 #include "limedriver.h"
 #include <H5PredType.h>
+#include <iostream>
 #include <lime/LimeSuite.h>
 #include <vector>
 
@@ -128,6 +129,8 @@ lms_device_t *openDevice(const std::string &info) {
     
     info_string = deviceList[0];
   }
+
+  cout << "Opening device: " << info_string << endl;
 
   lms_device_t *dev = NULL;
   if (LMS_Open(&dev, info.c_str(), NULL)) {

--- a/src/limedriver.cpp
+++ b/src/limedriver.cpp
@@ -834,20 +834,6 @@ int run_experiment(LimeConfig_t LimeCfg,
   if (LMS_Open(&device, list[0].c_str(), NULL))
     error();
 
-  /*
-          //print available antennae names
-          //select antenna port
-          lms_name_t antenna_list[10];    //large enough list for antenna names.
-          //Alternatively, NULL can be passed to LMS_GetAntennaList() to obtain
-     number of antennae if ((n = LMS_GetAntennaList(device, LMS_CH_RX, 0,
-     antenna_list)) < 0) error();
-
-          // get and print antenna index and name
-          if ((n = LMS_GetAntenna(device, LMS_CH_RX, 0)) < 0) error();
-          cout << "Automatically selected RX LNA: " << n << ": " <<
-     antenna_list[n] << endl;
-  */
-
   // Get number of channels
   int num_rx_channels, num_tx_channels;
   if ((num_rx_channels = LMS_GetNumChannels(device, LMS_CH_RX)) < 0)

--- a/src/limedriver.cpp
+++ b/src/limedriver.cpp
@@ -130,8 +130,6 @@ lms_device_t *openDevice(const std::string &info) {
     info_string = deviceList[0];
   }
 
-  cout << "Opening device: " << info_string << endl;
-
   lms_device_t *dev = NULL;
   if (LMS_Open(&dev, info_string.c_str(), NULL)) {
     error();

--- a/src/limedriver.h
+++ b/src/limedriver.h
@@ -140,4 +140,6 @@ LimeConfig_t initializeLimeConfig(int Npulses);
 */
 int run_experiment_from_LimeCfg(LimeConfig_t LimeCfg);
 
+std::vector<std::string> getDeviceList();
+
 #endif // LIMECONFIG_H

--- a/src/limedriver.h
+++ b/src/limedriver.h
@@ -28,6 +28,8 @@
 
 struct LimeConfig_t {
 
+  std::string device;
+
   float srate;
   int channel;
   int RX_matching;

--- a/src/limedriver.h
+++ b/src/limedriver.h
@@ -24,7 +24,7 @@
 #include <direct.h> // _mkdir
 #endif
 
-#define VERSION "0.3.0"
+#define VERSION "0.4.0"
 
 struct LimeConfig_t {
 

--- a/src/limedriver.h
+++ b/src/limedriver.h
@@ -140,6 +140,9 @@ LimeConfig_t initializeLimeConfig(int Npulses);
 */
 int run_experiment_from_LimeCfg(LimeConfig_t LimeCfg);
 
+std::pair<int, int> getDeviceChannels(lms_device_t *dev);
+std::pair<int, int> getChannelsFromInfo(const std::string &info);
+
 std::vector<std::string> getDeviceList();
 
 #endif // LIMECONFIG_H


### PR DESCRIPTION
This PR adds two features:

First, it allows passing a device info string as a parameter, allowing selection of a specific LimeSDR when multiple are connected simultaneously (falling back to the first identified device when undefined).

In addition, it adds functions to retrieve the number of TX and RX channels available on the selected LimeSDR, and a check for validity of the selected channel when running an experiment.

N.B.: On the LimeDriverBinding side, this probably requires a change to the LimeConfig object reflecting the added parameter.